### PR TITLE
fix: add missing state transition methods and exception to Job

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="d2e85850-aaaf-4257-8bd6-058aa5d23132" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/enums/JobStatus.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/model/Job.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/model/Job.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/model/Job.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -56,24 +56,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Application.VisionforgeApplication.executor": "Run",
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.MCP Project settings loaded": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "Spring Boot.VisionforgeApplication.executor": "Run",
-    "git-widget-placeholder": "feat/domain-model",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/Users/Cliente/cursos/visionforge",
-    "project.structure.last.edited": "Project",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
-    "settings.editor.selected.configurable": "com.android.studio.ml.bot.mainConfigurable"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Application.VisionforgeApplication.executor&quot;: &quot;Run&quot;,
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;Spring Boot.VisionforgeApplication.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feat/domain-model&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/Cliente/cursos/visionforge&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;com.android.studio.ml.bot.mainConfigurable&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\Cliente\cursos\visionforge" />

--- a/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java
+++ b/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java
@@ -1,0 +1,9 @@
+package com.visionforge.domain.exception;
+
+import com.visionforge.domain.enums.JobStatus;
+
+public class InvalidJobStateTransitionException extends RuntimeException {
+    public InvalidJobStateTransitionException(JobStatus currentStatus, JobStatus targetStatus) {
+        super(String.format("Não é possível transitar do estado %s para %s", currentStatus, targetStatus));
+    }
+}

--- a/src/main/java/com/visionforge/domain/model/Job.java
+++ b/src/main/java/com/visionforge/domain/model/Job.java
@@ -1,6 +1,7 @@
 package com.visionforge.domain.model;
 
 import com.visionforge.domain.enums.JobStatus;
+import com.visionforge.domain.exception.InvalidJobStateTransitionException;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -27,4 +28,28 @@ public class Job {
     public Instant getCreatedAt() { return createdAt; }
     public Instant getFinishedAt() { return finishedAt; }
     public String getFailureReason() { return failureReason; }
+
+    public void start() {
+        if (this.status != JobStatus.CREATED) {
+            throw new InvalidJobStateTransitionException(this.status, JobStatus.RUNNING);
+        }
+        this.status = JobStatus.RUNNING;
+    }
+
+    public void complete() {
+        if (this.status != JobStatus.RUNNING) {
+            throw new InvalidJobStateTransitionException(this.status, JobStatus.DONE);
+        }
+        this.status = JobStatus.DONE;
+        this.finishedAt = Instant.now();
+    }
+
+    public void fail(String reason) {
+        if (this.status != JobStatus.RUNNING) {
+            throw new InvalidJobStateTransitionException(this.status, JobStatus.FAILED);
+        }
+        this.status = JobStatus.FAILED;
+        this.failureReason = reason;
+        this.finishedAt = Instant.now();
+    }
 }


### PR DESCRIPTION
## Summary
Fix/Follow-up for PR #1. 
In the previous PR description, I mentioned adding the state transition rules to the `Job` entity and the custom exception, but those files/changes were accidentally left out of the final commit. 
This PR brings exclusively the missing behavioral methods (`start()`, `complete()`, and `fail()`) and the `InvalidJobStateTransitionException` class to properly encapsulate our domain rules.

## Related Issue / Task
Follow-up to PR #1

## Changes
- [x] Domain / Use-cases (Behavior added to existing entity)

## How to Test
1. Check `src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java`.
2. Review the new methods added to `src/main/java/com/visionforge/domain/model/Job.java` (`start`, `complete`, `fail`).
3. Verify that invalid state transitions properly throw the custom exception.

## Notes for Reviewers
The domain remains 100% isolated from external frameworks. No Spring/JPA dependencies were added.