### PR TITLE
feat: implement job state transition logic and business rules

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="d2e85850-aaaf-4257-8bd6-058aa5d23132" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/model/Job.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/visionforge/domain/model/Job.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -56,24 +56,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Application.VisionforgeApplication.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;Spring Boot.VisionforgeApplication.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feat/domain-model&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/Cliente/cursos/visionforge&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;com.android.studio.ml.bot.mainConfigurable&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Application.VisionforgeApplication.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.MCP Project settings loaded": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "Spring Boot.VisionforgeApplication.executor": "Run",
+    "git-widget-placeholder": "feat/add-job-behavior",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "C:/Users/Cliente/cursos/visionforge",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.0",
+    "project.structure.side.proportion": "0.0",
+    "settings.editor.selected.configurable": "com.android.studio.ml.bot.mainConfigurable"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\Cliente\cursos\visionforge" />

--- a/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java
+++ b/src/main/java/com/visionforge/domain/exception/InvalidJobStateTransitionException.java
@@ -4,6 +4,6 @@ import com.visionforge.domain.enums.JobStatus;
 
 public class InvalidJobStateTransitionException extends RuntimeException {
     public InvalidJobStateTransitionException(JobStatus currentStatus, JobStatus targetStatus) {
-        super(String.format("Não é possível transitar do estado %s para %s", currentStatus, targetStatus));
+        super(String.format("Cannot transition from state %s to %s", currentStatus, targetStatus));
     }
 }

--- a/src/main/java/com/visionforge/domain/model/Job.java
+++ b/src/main/java/com/visionforge/domain/model/Job.java
@@ -23,11 +23,6 @@ public class Job {
         return new Job(UUID.randomUUID(), JobStatus.CREATED, Instant.now());
     }
 
-    public UUID getId() { return id; }
-    public JobStatus getStatus() { return status; }
-    public Instant getCreatedAt() { return createdAt; }
-    public Instant getFinishedAt() { return finishedAt; }
-    public String getFailureReason() { return failureReason; }
 
     public void start() {
         if (this.status != JobStatus.CREATED) {
@@ -44,12 +39,24 @@ public class Job {
         this.finishedAt = Instant.now();
     }
 
+
     public void fail(String reason) {
-        if (this.status != JobStatus.RUNNING) {
+        if (this.status != JobStatus.CREATED && this.status != JobStatus.RUNNING) {
             throw new InvalidJobStateTransitionException(this.status, JobStatus.FAILED);
         }
+
+        if (reason == null || reason.isBlank()) {
+            throw new InvalidJobStateTransitionException(this.status, JobStatus.FAILED);
+        }
+
         this.status = JobStatus.FAILED;
         this.failureReason = reason;
         this.finishedAt = Instant.now();
     }
+
+    public UUID getId() { return id; }
+    public JobStatus getStatus() { return status; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getFinishedAt() { return finishedAt; }
+    public String getFailureReason() { return failureReason; }
 }


### PR DESCRIPTION
## Summary
Refactored the Job entity to include business logic for state transitions (start, complete, fail). Added custom exception handling for invalid transitions and ensured English naming conventions.

## Related Issue / Task
Closes #1

## Changes
- [ ] API
- [x] Domain / Use-cases
- [ ] Persistence (JPA/Flyway)
- [ ] Tests

## How to Test
1. Create a Job using `Job.create()`.
2. Call `start()` and verify status change to RUNNING.
3. Call `fail("reason")` from CREATED or RUNNING state and verify status FAILED.
4. Try to call `complete()` from CREATED state to trigger `InvalidJobStateTransitionException`.

## Checklist
- [x] I ran the project locally
- [x] I handled validation and error cases
- [x] I kept the PR reasonably small and focused