### PR TITLE
feat: implement RabbitMQ consumer to process jobs

### DIFF
--- a/src/main/java/com/visionforge/infrastructure/messaging/RabbitMQJobConsumer.java
+++ b/src/main/java/com/visionforge/infrastructure/messaging/RabbitMQJobConsumer.java
@@ -36,6 +36,7 @@ public class RabbitMQJobConsumer {
 
         } catch (Exception e) {
             System.err.println("[Worker] ❌ Error processing Job " + message + ": " + e.getMessage());
+            throw new RuntimeException("Failure processing RabbitMQ event", e);
         }
     }
 }

--- a/src/main/java/com/visionforge/infrastructure/messaging/RabbitMQJobConsumer.java
+++ b/src/main/java/com/visionforge/infrastructure/messaging/RabbitMQJobConsumer.java
@@ -1,0 +1,41 @@
+package com.visionforge.infrastructure.messaging;
+
+import com.visionforge.application.usecase.StartJobUseCase;
+import com.visionforge.application.usecase.CompleteJobUseCase;
+import com.visionforge.infrastructure.config.RabbitMQConfig;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class RabbitMQJobConsumer {
+
+    private final StartJobUseCase startJobUseCase;
+    private final CompleteJobUseCase completeJobUseCase;
+
+    public RabbitMQJobConsumer(StartJobUseCase startJobUseCase, CompleteJobUseCase completeJobUseCase) {
+        this.startJobUseCase = startJobUseCase;
+        this.completeJobUseCase = completeJobUseCase;
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_CREATED)
+    public void consumeJobCreatedMessage(String message) {
+        System.out.println("\n[Worker] 🚀 New message received from queue! Job ID: " + message);
+
+        try {
+            UUID jobId = UUID.fromString(message);
+
+            startJobUseCase.execute(jobId);
+            System.out.println("[Worker] ⏳ Job " + jobId + " updated to RUNNING. Starting image processing...");
+
+            Thread.sleep(5000);
+
+            completeJobUseCase.execute(jobId);
+            System.out.println("[Worker] ✅ Processing completed! Job " + jobId + " updated to DONE!");
+
+        } catch (Exception e) {
+            System.err.println("[Worker] ❌ Error processing Job " + message + ": " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/visionforge/infrastructure/messaging/RabbitMQJobEventForwarder.java
+++ b/src/main/java/com/visionforge/infrastructure/messaging/RabbitMQJobEventForwarder.java
@@ -28,6 +28,6 @@ public class RabbitMQJobEventForwarder {
                 message
         );
 
-        System.out.println("[Event Forwarder] Evento capturado! ID enviado para o RabbitMQ: " + message);
+        System.out.println("[Event Forwarder] Event captured! ID sent to RabbitMQ: " + message);
     }
 }


### PR DESCRIPTION
## Summary
Implements the RabbitMQ Consumer (`RabbitMQJobConsumer`) to process newly created jobs. The worker listens to the `visionforge.job.created.queue`, retrieves the job ID, and orchestrates the processing lifecycle:
1. Transitions the job status to `RUNNING` (via `StartJobUseCase`).
2. Simulates the heavy image processing work (currently a 5-second thread sleep).
3. Transitions the job status to `DONE` (via `CompleteJobUseCase`).

## Related Issue / Task
Updates #7

## Changes
- [ ] API
- [ ] Domain / Use-cases
- [ ] Persistence (JPA/Flyway)
- [x] Messaging (RabbitMQ)
- [x] Worker / Processing pipeline
- [ ] Tests
- [ ] Docs

## How to Test
1. Ensure the RabbitMQ container is running (`docker-compose up -d`).
2. Start the Spring Boot application locally.
3. Open the Swagger UI at `http://localhost:8080/swagger-ui/index.html`.
4. Execute a `POST` request to `/api/v1/jobs` to create a new job.
5. Check the application console. You should see:
   - The producer sending the event.
   - The consumer picking up the message and changing the status to `RUNNING`.
   - A 5-second pause (simulating processing).
   - The final log confirming the status was updated to `DONE`.

## Checklist
- [x] I ran the project locally (or provided steps to run)
- [ ] I added/updated tests (or explained why not) -> *Tests will be addressed in a future phase.*
- [x] I handled validation and error cases (Try/Catch block in the listener)
- [x] I did not commit secrets (tokens, passwords, keys)
- [ ] I updated docs/README if behavior changed
- [x] I kept the PR reasonably small and focused

## Notes for Reviewers
- The actual image processing logic is currently mocked with a `Thread.sleep(5000)`. This placeholder will be replaced with the real computer vision logic in the upcoming phases.